### PR TITLE
Few fixes

### DIFF
--- a/_config.inc.php
+++ b/_config.inc.php
@@ -22,8 +22,3 @@ declare(strict_types=1);
  */
 
 define('COURSES_PREFIX', 'courses_');
-
-// Force gettext to return UTF-8 regardless of system locale (PHP 8.x)
-if (function_exists('bind_textdomain_codeset')) {
-    bind_textdomain_codeset('courses', 'UTF-8');
-}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "galette-plugin",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/doc/cahier-des-charges.md
+++ b/doc/cahier-des-charges.md
@@ -1032,7 +1032,7 @@ La barre laterale contient **deux groupes de menus** distincts :
 ### 6.1 Compatibilite
 
 - Galette >= 1.2.0
-- PHP >= 8.1 (compatible 8.1, 8.2, 8.3, 8.4)
+- PHP >= 8.2 (compatible 8.2, 8.3, 8.4, 8.5)
 - MySQL / MariaDB
 - Fomantic UI (integre a Galette)
 

--- a/doc/mode-emploi.md
+++ b/doc/mode-emploi.md
@@ -42,7 +42,7 @@ Pour un evenement ponctuel, une seance unique est creee automatiquement a la cre
 ### Prerequis
 
 - Galette >= 1.2.0
-- PHP >= 8.1 (compatible 8.1, 8.2, 8.3, 8.4)
+- PHP >= 8.2 (compatible 8.2, 8.3, 8.4, 8.5)
 - MySQL / MariaDB
 
 ### Procedure

--- a/lib/GaletteCourses/Entity/Event.php
+++ b/lib/GaletteCourses/Entity/Event.php
@@ -424,12 +424,12 @@ class Event
             $children = $adherent->children;
             if (!empty($children)) {
                 foreach ($children as $child) {
-                    $child_id = is_object($child) ? $child->id : (int)$child;
+                    $child_id = $child->id;
                     if ($child_id > 0) {
                         $child_adh = new \Galette\Entity\Adherent($this->zdb, $child_id);
                         $child_groups = $child_adh->getGroups();
                         foreach ($child_groups as $group) {
-                            $gid = is_object($group) ? $group->getId() : (int)$group;
+                            $gid = $group->getId();
                             if (in_array($gid, $this->groups)) {
                                 return true;
                             }

--- a/lib/GaletteCourses/Entity/Session.php
+++ b/lib/GaletteCourses/Entity/Session.php
@@ -37,13 +37,6 @@ class Session
     public const STATUS_CLOSED = 'closed';
     public const STATUS_CANCELLED = 'cancelled';
 
-    public const CANCEL_REASONS = [
-        'concours' => 'Competition',
-        'absence_moniteur' => 'Instructor absent',
-        'formation' => 'Training',
-        'meteo' => 'Weather',
-        'autre' => 'Other',
-    ];
 
     private int $id;
     private int $event_id;


### PR DESCRIPTION
I just take a quick look, I do not have time to proceed a full review or a full test.

Some remarks:
- you should remove the `master` branch since the main one is the default. I advice you to create a `develop` branch for work on next Galette major,
- The "FRENCH_*" constants seems really weird; this just make plugin unusable for anyone that does not speak French. Also, PHP has native methods to display localized dates.
- Date format should never been hardcoded (`'d/m/Y` ==> `_T('Y-m-d')`)
- Scripts directory contains a useless `upgrade-unsubscribe.sql` file that may be removed. SQL migrations must be done on a version basis.

Additionally:
- You should probably reduce the ACLs list using regular expressions
- Is this really required to maintain a python script for a Word export? MD are visible inline, it's certainly enough

Those lists are non exhaustive. 
Review can be made per commit.